### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/pylon-api/CHANGELOG.md
+++ b/pylon-api/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2024-03-21
+
+### Added
+- Added `snooze_issue` method to support the new issue snooze endpoint
+
 ## [0.1.0] - 2024-03-21
 
 ### Added
@@ -31,4 +36,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - YARD documentation for all methods
 - MIT License
 
+[0.2.0]: https://github.com/benjodo/pylon-api/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/benjodo/pylon-api/releases/tag/v0.1.0 

--- a/pylon-api/lib/pylon/version.rb
+++ b/pylon-api/lib/pylon/version.rb
@@ -4,7 +4,7 @@ module Pylon
   # Major version for breaking changes
   MAJOR = 0
   # Minor version for new features
-  MINOR = 1
+  MINOR = 2
   # Patch version for bug fixes
   PATCH = 0
   # Pre-release version (optional)


### PR DESCRIPTION
This PR bumps the gem version to 0.2.0 to reflect the addition of the `snooze_issue` functionality.

Changes:
- Bumped minor version from 0.1.0 to 0.2.0
- Updated CHANGELOG.md with new version entry

Following semantic versioning, this is a minor version bump as it:
- Adds new functionality (`snooze_issue`)
- Maintains backwards compatibility
- Occurs during pre-1.0 development

After merging, we'll create and push a new gem release to RubyGems.org.