### PR TITLE
Fix Attachment Creation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,39 @@
+AllCops:
+  TargetRubyVersion: 3.0
+  NewCops: enable
+  Exclude:
+    - 'bin/**/*'
+    - 'vendor/**/*'
+    - 'tmp/**/*'
+    - 'db/**/*'
+    - 'node_modules/**/*'
+
+Metrics/ClassLength:
+  Max: 300
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/Documentation:
+  Enabled: false
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+
+Metrics/MethodLength:
+  Max: 20
+
+Metrics/AbcSize:
+  Max: 30
+
+Layout/LineLength:
+  Max: 120
+  Exclude:
+    - 'spec/**/*'
+
+RSpec/MultipleExpectations:
+  Max: 5
+
+RSpec/ExampleLength:
+  Max: 20 

--- a/README.md
+++ b/README.md
@@ -171,8 +171,18 @@ form = client.create_ticket_form(
 #### Attachments
 
 ```ruby
-# Create an attachment
+# Create an attachment from raw content
 attachment = client.create_attachment(file_content)
+
+# Create an attachment from a file
+file = File.open('document.pdf', 'rb')
+attachment = client.create_attachment(file)
+
+# Create an attachment from a URL with description
+attachment = client.create_attachment(nil, 
+  file_url: 'https://example.com/document.pdf',
+  description: 'Important document'
+)
 ```
 
 ## Error Handling

--- a/pylon-api/CHANGELOG.md
+++ b/pylon-api/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.1.1] - 2025-04-18
+
+### Fixed
+- Fixed URL-based file attachments by ensuring they use proper multipart form encoding
+
+## [1.1.0] - 2025-04-17
+
+### Added
+- Support for URL-based file attachments
+- Enhanced attachment handling for various file types
+- Added MIME type detection for file uploads
+
 ## [1.0.0] - 2024-03-21
 
 ### Changed

--- a/pylon-api/lib/pylon.rb
+++ b/pylon-api/lib/pylon.rb
@@ -3,6 +3,7 @@
 require "faraday"
 require "faraday/multipart"
 require "json"
+require "tempfile"
 
 require_relative "pylon/version"
 require_relative "pylon/models/base"

--- a/pylon-api/lib/pylon/client.rb
+++ b/pylon-api/lib/pylon/client.rb
@@ -7,6 +7,7 @@ module Pylon
   #   client = Pylon::Client.new(api_key: 'your_api_key')
   #   issues = client.list_issues(start_time: '2024-03-01T00:00:00Z', end_time: '2024-03-31T23:59:59Z')
   #   issues.each { |issue| puts issue.title }
+  # rubocop:disable Metrics/ClassLength
   class Client
     # Common MIME types for file uploads
     MIME_TYPES = {

--- a/pylon-api/lib/pylon/version.rb
+++ b/pylon-api/lib/pylon/version.rb
@@ -6,7 +6,7 @@ module Pylon
   # Minor version for new features
   MINOR = 1
   # Patch version for bug fixes
-  PATCH = 0
+  PATCH = 1
   # Pre-release version (optional)
   PRE = nil
 

--- a/pylon-api/spec/pylon/client_spec.rb
+++ b/pylon-api/spec/pylon/client_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe Pylon::Client do
       end
 
       context "with file path" do
-        let(:temp_file) { Tempfile.new(['test', '.txt']) }
+        let(:temp_file) { Tempfile.new(["test", ".txt"]) }
 
         before do
           temp_file.write("test content")
@@ -223,8 +223,8 @@ RSpec.describe Pylon::Client do
           stub_request(:post, "https://api.usepylon.com/attachments")
             .with(
               headers: {
-                'Accept' => 'application/json',
-                'Authorization' => 'Bearer test_api_key'
+                "Accept" => "application/json",
+                "Authorization" => "Bearer test_api_key"
               }
             )
             .to_return(

--- a/pylon-api/spec/pylon/client_spec.rb
+++ b/pylon-api/spec/pylon/client_spec.rb
@@ -144,21 +144,110 @@ RSpec.describe Pylon::Client do
 
   describe "attachments" do
     describe "#create_attachment" do
-      let(:file) { "file_content" }
-      let(:attachment_data) { { "id" => "1", "url" => "https://example.com/file.pdf" } }
-
-      before do
-        stub_pylon_request(:post, "/attachments",
-                           response_body: attachment_data,
-                           headers: auth_headers.merge(rate_limit_headers))
+      let(:attachment_data) { { "id" => "1", "url" => "https://example.com/file.pdf", "name" => "test.pdf" } }
+      let(:rate_limit_headers) do
+        {
+          "x-rate-limit-limit" => "100",
+          "x-rate-limit-remaining" => "99",
+          "x-rate-limit-reset" => Time.now.to_i.to_s
+        }
       end
 
-      it "creates an attachment" do
-        attachment = client.create_attachment(file)
-        expect(attachment).to be_a(Pylon::Models::Attachment)
-        expect(attachment.id).to eq("1")
-        expect(attachment.url).to eq("https://example.com/file.pdf")
-        expect(attachment._response.headers["x-rate-limit-remaining"]).to eq("99")
+      context "with file content" do
+        let(:file_content) { "file_content" }
+
+        before do
+          stub_request(:post, "https://api.usepylon.com/attachments")
+            .with(
+              headers: {
+                "Accept" => "application/json",
+                "Authorization" => "Bearer test_api_key"
+              }
+            )
+            .to_return(
+              status: 200,
+              body: attachment_data.to_json,
+              headers: { "Content-Type" => "application/json" }.merge(rate_limit_headers)
+            )
+        end
+
+        it "creates an attachment with file content" do
+          attachment = client.create_attachment(file_content)
+          expect(attachment).to be_a(Pylon::Models::Attachment)
+          expect(attachment.id).to eq("1")
+          expect(attachment.url).to eq("https://example.com/file.pdf")
+          expect(attachment.name).to eq("test.pdf")
+          expect(attachment._response.headers["x-rate-limit-remaining"]).to eq("99")
+        end
+      end
+
+      context "with file path" do
+        let(:temp_file) { Tempfile.new(['test', '.txt']) }
+
+        before do
+          temp_file.write("test content")
+          temp_file.rewind
+
+          stub_request(:post, "https://api.usepylon.com/attachments")
+            .with(
+              headers: {
+                "Accept" => "application/json",
+                "Authorization" => "Bearer test_api_key"
+              }
+            )
+            .to_return(
+              status: 200,
+              body: attachment_data.to_json,
+              headers: { "Content-Type" => "application/json" }.merge(rate_limit_headers)
+            )
+        end
+
+        after do
+          temp_file.close
+          temp_file.unlink
+        end
+
+        it "creates an attachment with a file object" do
+          attachment = client.create_attachment(temp_file)
+          expect(attachment).to be_a(Pylon::Models::Attachment)
+          expect(attachment.id).to eq("1")
+        end
+      end
+
+      context "with file_url" do
+        let(:file_url) { "https://example.com/somefile.pdf" }
+          
+        before do
+          # Use a simpler stub that only matches on URL and headers, not body
+          # since WebMock doesn't support matching multipart form data
+          stub_request(:post, "https://api.usepylon.com/attachments")
+            .with(
+              headers: {
+                'Accept' => 'application/json',
+                'Authorization' => 'Bearer test_api_key'
+              }
+            )
+            .to_return(
+              status: 200,
+              body: attachment_data.to_json,
+              headers: { "Content-Type" => "application/json" }.merge(rate_limit_headers)
+            )
+        end
+
+        it "creates an attachment with a URL" do
+          attachment = client.create_attachment(nil, description: "Test file", file_url: file_url)
+          expect(attachment).to be_a(Pylon::Models::Attachment)
+          expect(attachment.id).to eq("1")
+          expect(attachment.url).to eq("https://example.com/file.pdf")
+        end
+      end
+
+      context "with missing parameters" do
+        it "raises ArgumentError when neither file nor file_url is provided" do
+          expect { client.create_attachment(nil) }.to raise_error(
+            ArgumentError, "Either file or file_url must be provided"
+          )
+        end
       end
     end
   end

--- a/pylon-api/test/test.rb
+++ b/pylon-api/test/test.rb
@@ -5,12 +5,12 @@ require "bundler/setup"
 require "pylon"
 require "tempfile"
 
-if ENV['PYLON_API_KEY'].nil?
+if ENV["PYLON_API_KEY"].nil?
   puts "Error: Please set the PYLON_API_KEY environment variable"
   exit 1
 end
 
-client = Pylon::Client.new(api_key: ENV['PYLON_API_KEY'], debug: true)
+client = Pylon::Client.new(api_key: ENV["PYLON_API_KEY"], debug: true)
 
 puts "--------- Testing Pylon API Attachment Upload Methods -----------"
 
@@ -41,7 +41,7 @@ end
 # Test 3: Create attachment from file
 begin
   puts "\nTest 3: Creating attachment from file..."
-  temp_file = Tempfile.new(['test_file', '.txt'])
+  temp_file = Tempfile.new(["test_file", ".txt"])
   temp_file.write("This is content from a file object.")
   temp_file.rewind
 

--- a/pylon-api/test/test.rb
+++ b/pylon-api/test/test.rb
@@ -3,13 +3,75 @@
 
 require "bundler/setup"
 require "pylon"
+require "tempfile"
 
-client = Pylon::Client.new(api_key: ENV.fetch("PYLON_API_KEY", nil))
+if ENV['PYLON_API_KEY'].nil?
+  puts "Error: Please set the PYLON_API_KEY environment variable"
+  exit 1
+end
 
-# Test the API
+client = Pylon::Client.new(api_key: ENV['PYLON_API_KEY'], debug: true)
+
+puts "--------- Testing Pylon API Attachment Upload Methods -----------"
+
+# Test 1: Get current user (to verify API key is working)
 begin
   me = client.get_current_user
-  puts "Successfully connected as: #{me['email']}"
-rescue StandardError => e
-  puts "Error: #{e.message}"
+  puts "Successfully connected as: #{me.name}"
+rescue => e
+  puts "Error connecting to API: #{e.message}"
+  puts e.backtrace.join("\n")
+  exit 1
 end
+
+# Test 2: Create attachment from string content
+begin
+  puts "\nTest 2: Creating attachment from string content..."
+  string_content = "This is a test file created from string content."
+  attachment = client.create_attachment(string_content, description: "Test string attachment")
+  puts "Success! Attachment created with ID: #{attachment.id}"
+  puts "URL: #{attachment.url}"
+  puts "Name: #{attachment.name}" if attachment.respond_to?(:name)
+  puts "Description: #{attachment.description}" if attachment.respond_to?(:description)
+rescue => e
+  puts "Error creating string attachment: #{e.message}"
+  puts e.backtrace.join("\n")
+end
+
+# Test 3: Create attachment from file
+begin
+  puts "\nTest 3: Creating attachment from file..."
+  temp_file = Tempfile.new(['test_file', '.txt'])
+  temp_file.write("This is content from a file object.")
+  temp_file.rewind
+
+  attachment = client.create_attachment(temp_file, description: "Test file attachment")
+  puts "Success! Attachment created with ID: #{attachment.id}"
+  puts "URL: #{attachment.url}"
+  puts "Name: #{attachment.name}" if attachment.respond_to?(:name)
+  puts "Description: #{attachment.description}" if attachment.respond_to?(:description)
+
+  temp_file.close
+  temp_file.unlink
+rescue => e
+  puts "Error creating file attachment: #{e.message}"
+  puts e.backtrace.join("\n")
+end
+
+# Test 4: Create attachment from URL
+begin
+  puts "\nTest 4: Creating attachment from URL..."
+  attachment = client.create_attachment(nil,
+    file_url: "https://upload.wikimedia.org/wikipedia/commons/thumb/7/73/Ruby_logo.svg/200px-Ruby_logo.svg.png",
+    description: "Ruby logo from URL"
+  )
+  puts "Success! Attachment created with ID: #{attachment.id}"
+  puts "URL: #{attachment.url}"
+  puts "Name: #{attachment.name}" if attachment.respond_to?(:name)
+  puts "Description: #{attachment.description}" if attachment.respond_to?(:description)
+rescue => e
+  puts "Error creating URL attachment: #{e.message}"
+  puts e.backtrace.join("\n")
+end
+
+puts "\nFinished testing!"


### PR DESCRIPTION
## Fix URL-based File Attachments

### Problem

The attachment upload functionality was failing when using the `file_url` parameter to create attachments from URLs.  
The API returned a `400` error with the message:

> "Failed to parse form, please make sure your file is less than 32 MB."

### Root Cause

When file uploads were made using a URL (without an actual file), the client sent a regular JSON POST request.  
However, the Pylon API expects all attachment uploads — including URL-based ones — to be submitted as multipart form requests.

### Solution

- Updated the `create_attachment` method to always use `post_multipart` for both file and URL-based attachments.
- Enhanced `post_multipart` to properly handle URL-based attachments by:
  - Removing the `url_encoded` middleware to avoid encoding issues.
  - Adding a dummy file part when only a URL is provided to ensure correct multipart form structure.

### Testing

- Updated unit tests to cover URL-based attachment behavior.
- Performed manual testing to confirm successful URL-based uploads.

### Version

- Bumped gem version from `v1.1.0` to `v1.1.1` (bug fix release).
